### PR TITLE
脱字の修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.6.0",
-    "prettier": "^2.4.1"
+    "prettier": "^2.4.1",
     "serverless-dotenv-plugin": "^3.9.0",
     "serverless-webpack": "^5.3.1",
     "webpack": "^4.35.2"


### PR DESCRIPTION
18行目` prettier": "^2.4.1 `の末尾に`,`が抜けていたため、追加いたしました。